### PR TITLE
Implementing vuln toggle, fixing bugs in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive repository and analysis tool for storing, organizing, and analyz
 - **Advanced Analytics**: View comprehensive statistics including vulnerability rates, test categories, and overall security posture
 - **Drill-down Analysis**: Examine individual test attempts and responses to understand specific failures
 - **False Positive Detection**: Analyze detector results and responses to identify potential false positives
+- **🔧 Configurable Report Editing**: Toggle vulnerability scores to mark false positives/negatives (can be disabled for read-only environments)
 - **Search & Filter**: Search through test categories and filter attempts by vulnerability status
 - **Detailed Response Analysis**: View full prompts, responses, and detector scores for each attempt
 - **🔐 OIDC Authentication**: Secure access with OpenID Connect integration supporting automated service discovery for various providers (Okta, Google, Azure AD, Auth0, Keycloak, AWS Cognito, and more)
@@ -170,6 +171,16 @@ The following environment variables can be configured:
 - **Path handling**: 
   - Relative paths are resolved from the project root
   - Absolute paths (starting with `/`) are used as-is
+
+#### `REPORT_READONLY` (Optional)
+- **Description**: Controls whether users can edit vulnerability scores in reports
+- **Default**: `false`
+- **Values**: 
+  - `true`: Reports are read-only, vulnerability scores cannot be modified
+  - `false`: Users can toggle vulnerability scores to mark false positives/negatives
+- **Use cases**: 
+  - Set to `true` for production environments where report integrity must be preserved
+  - Set to `false` for analysis environments where analysts need to mark false positives
 
 ### OIDC Authentication (Optional)
 

--- a/example.env
+++ b/example.env
@@ -108,6 +108,12 @@ OIDC_MAX_AGE=3600
 # OIDC_PROVIDER_NAME=AWS Cognito
 # OIDC_SCOPES=openid,profile,email
 
+# Report Editing Configuration
+# Controls whether users can edit vulnerability scores in reports
+# When set to true, reports are read-only and vulnerability scores cannot be modified
+# When set to false (default), users can toggle vulnerability scores
+REPORT_READONLY=false
+
 # Shared Secret Authentication for Machine-to-Machine Communication
 # This enables API authentication using a shared secret for automated services
 # When set, API endpoints can be accessed using:

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { isReportReadonly } from '@/lib/config';
+
+export async function GET() {
+  try {
+    return NextResponse.json({
+      reportReadonly: isReportReadonly()
+    });
+  } catch (error) {
+    console.error('Failed to get config:', error);
+    return NextResponse.json(
+      { error: 'Failed to get configuration' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/garak-report-attempts/route.ts
+++ b/src/app/api/garak-report-attempts/route.ts
@@ -160,23 +160,28 @@ function parseCategoryAttempts(
   filter: string
 ): AttemptResult {
   const lines = jsonlContent.trim().split('\n');
-  const allAttempts = [];
   
-  // First pass: collect all attempts for the category
+  // First pass: collect all attempts for the category, deduplicating by UUID
+  const attemptsByUuid = new Map();
+  
   for (const line of lines) {
     try {
       const entry = JSON.parse(line);
       
-      if (entry.entry_type === 'attempt') {
+      if (entry.entry_type === 'attempt' && entry.status === 2) {
         const attemptCategory = getCategoryName(entry.probe_classname);
         if (attemptCategory === category) {
-          allAttempts.push(entry);
+          // Only include status 2 (evaluated) attempts
+          attemptsByUuid.set(entry.uuid, entry);
         }
       }
     } catch {
       console.warn('Failed to parse line:', line);
     }
   }
+  
+  // Convert map values to array
+  const allAttempts = Array.from(attemptsByUuid.values());
   
   // Apply filter
   let filteredAttempts = allAttempts;

--- a/src/app/api/garak-report-toggle/route.ts
+++ b/src/app/api/garak-report-toggle/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from 'next/server';
+import { readFileSync, writeFileSync } from 'fs';
+import { 
+  validateFilename, 
+  validateReportDirectory, 
+  buildSafeFilePath, 
+  validateFile, 
+  sanitizeError 
+} from '@/lib/security';
+import { isReportReadonly } from '@/lib/config';
+
+export async function POST(request: Request) {
+  try {
+    // Check if reports are in readonly mode
+    if (isReportReadonly()) {
+      return NextResponse.json(
+        { error: 'Report editing is disabled. Reports are in readonly mode.' },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+    const { filename, attemptUuid, responseIndex, detectorName, newScore } = body;
+    
+    // Validate required fields
+    if (!filename || !attemptUuid || responseIndex === undefined || !detectorName || newScore === undefined) {
+      return NextResponse.json(
+        { error: 'Missing required fields: filename, attemptUuid, responseIndex, detectorName, newScore' },
+        { status: 400 }
+      );
+    }
+    
+    // Validate filename
+    const filenameValidation = validateFilename(filename);
+    if (!filenameValidation.isValid) {
+      return NextResponse.json(
+        { error: filenameValidation.error },
+        { status: 400 }
+      );
+    }
+    
+    // Validate newScore is 0 or 1
+    if (newScore !== 0 && newScore !== 1) {
+      return NextResponse.json(
+        { error: 'newScore must be 0 or 1' },
+        { status: 400 }
+      );
+    }
+    
+    // Validate responseIndex is a non-negative integer
+    if (!Number.isInteger(responseIndex) || responseIndex < 0) {
+      return NextResponse.json(
+        { error: 'responseIndex must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+    
+    // Validate and sanitize report directory
+    const reportDir = process.env.REPORT_DIR || './data';
+    const dirValidation = validateReportDirectory(reportDir);
+    if (!dirValidation.isValid) {
+      return NextResponse.json(
+        { error: 'Invalid report directory configuration' },
+        { status: 500 }
+      );
+    }
+    
+    // Build safe file path
+    const pathValidation = buildSafeFilePath(reportDir, filename);
+    if (!pathValidation.isValid) {
+      return NextResponse.json(
+        { error: pathValidation.error },
+        { status: 400 }
+      );
+    }
+    
+    // Validate file before reading
+    const fileValidation = validateFile(pathValidation.filePath!);
+    if (!fileValidation.isValid) {
+      return NextResponse.json(
+        { error: fileValidation.error },
+        { status: 404 }
+      );
+    }
+    
+    // Read the report file
+    const reportContent = readFileSync(pathValidation.filePath!, 'utf-8');
+    const lines = reportContent.trim().split('\n');
+    
+    // Find and update the specific attempt
+    let found = false;
+    let targetLineIndex = -1;
+    
+    // First pass: find the entry with status 2 (evaluated) for this UUID
+    lines.forEach((line, index) => {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.entry_type === 'attempt' && entry.uuid === attemptUuid && entry.status === 2) {
+          // Only target status 2 (evaluated) entries since that's what we display
+          targetLineIndex = index;
+        }
+      } catch {
+        // Skip invalid lines
+      }
+    });
+    
+    if (targetLineIndex === -1) {
+      return NextResponse.json(
+        { error: `Attempt with UUID ${attemptUuid} not found` },
+        { status: 404 }
+      );
+    }
+    
+    const updatedLines = lines.map((line, index) => {
+      try {
+        const entry = JSON.parse(line);
+        
+        if (entry.entry_type === 'attempt' && entry.uuid === attemptUuid && index === targetLineIndex) {
+          found = true;
+          
+          // Update the detector result for the specific response
+          if (entry.detector_results && entry.detector_results[detectorName]) {
+            const scores = entry.detector_results[detectorName];
+            if (Array.isArray(scores) && responseIndex < scores.length) {
+              // Create a copy of the entry and update the score
+              const updatedEntry = { ...entry };
+              updatedEntry.detector_results = { ...entry.detector_results };
+              updatedEntry.detector_results[detectorName] = [...scores];
+              updatedEntry.detector_results[detectorName][responseIndex] = newScore;
+              
+              return JSON.stringify(updatedEntry);
+            } else {
+              throw new Error(`Invalid responseIndex ${responseIndex} for detector ${detectorName}`);
+            }
+          } else {
+            // If detector doesn't exist, create a custom detector
+            const updatedEntry = { ...entry };
+            updatedEntry.detector_results = { ...entry.detector_results };
+            
+            // Create scores array with 0s for all responses, then set the target response
+            const numOutputs = entry.outputs ? entry.outputs.length : 1;
+            const scores = new Array(numOutputs).fill(0);
+            scores[responseIndex] = newScore;
+            
+            updatedEntry.detector_results[detectorName] = scores;
+            
+            return JSON.stringify(updatedEntry);
+          }
+        }
+        
+        return line;
+      } catch (error) {
+        console.warn('Failed to parse line:', line, error);
+        return line;
+      }
+    });
+    
+    if (!found) {
+      return NextResponse.json(
+        { error: `Failed to update attempt with UUID ${attemptUuid}` },
+        { status: 500 }
+      );
+    }
+    
+    // Write the updated content back to the file
+    const updatedContent = updatedLines.join('\n');
+    writeFileSync(pathValidation.filePath!, updatedContent, 'utf-8');
+    
+    return NextResponse.json({ 
+      success: true, 
+      message: `Updated detector ${detectorName} score for response ${responseIndex} to ${newScore}` 
+    });
+    
+  } catch (error) {
+    const sanitizedError = sanitizeError(error);
+    return NextResponse.json(
+      { error: sanitizedError },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/ResponseToggle.tsx
+++ b/src/components/ResponseToggle.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { apiJson } from '@/lib/api-client';
+
+interface ResponseToggleProps {
+  attemptUuid: string;
+  responseIndex: number;
+  detectorName: string;
+  currentScore: number;
+  filename: string;
+  onToggle: (newScore: number) => void;
+}
+
+export function ResponseToggle({ 
+  attemptUuid, 
+  responseIndex, 
+  detectorName, 
+  currentScore, 
+  filename,
+  onToggle 
+}: ResponseToggleProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleToggle = async () => {
+    const newScore = currentScore > 0.5 ? 0 : 1;
+    
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const response = await apiJson<{ success: boolean; error?: string; message?: string }>('/api/garak-report-toggle', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          filename,
+          attemptUuid,
+          responseIndex,
+          detectorName,
+          newScore
+        })
+      });
+      
+      // Only update if the API call was successful
+      if (response.success) {
+        onToggle(newScore);
+      } else {
+        setError(response.error || 'Failed to update score');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update score');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const isVulnerable = currentScore > 0.5;
+
+  return (
+    <div className="flex items-center space-x-2">
+      {error && (
+        <span className="text-xs text-red-600 bg-red-50 px-2 py-1 rounded">
+          {error}
+        </span>
+      )}
+      <button
+        onClick={handleToggle}
+        disabled={isLoading}
+        className={`
+          relative inline-flex h-6 w-11 items-center rounded-full transition-colors
+          ${isVulnerable ? 'bg-red-600' : 'bg-gray-200'}
+          ${isLoading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+        `}
+        title={`Toggle vulnerability (currently ${isVulnerable ? 'vulnerable' : 'safe'})`}
+      >
+        <span
+          className={`
+            inline-block h-4 w-4 transform rounded-full bg-white transition-transform
+            ${isVulnerable ? 'translate-x-6' : 'translate-x-1'}
+          `}
+        />
+      </button>
+      <span className="text-xs text-gray-500">
+        {isVulnerable ? 'Vulnerable' : 'Safe'}
+      </span>
+      {isLoading && (
+        <div className="animate-spin rounded-full h-3 w-3 border-b border-gray-600"></div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,6 +11,7 @@ export interface AppConfig {
   nextAuthUrl: string;
   nextAuthSecret: string;
   sharedSecret: string;
+  reportReadonly: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export function getAppConfig(): AppConfig {
     nextAuthUrl: process.env.NEXTAUTH_URL || 'http://localhost:3000',
     nextAuthSecret: process.env.NEXTAUTH_SECRET || '',
     sharedSecret: process.env.SHARED_SECRET || '',
+    reportReadonly: process.env.REPORT_READONLY === 'true',
   };
 }
 
@@ -31,4 +33,11 @@ export function getAppConfig(): AppConfig {
  */
 export function isOIDCEnabled(): boolean {
   return process.env.OIDC_ENABLED !== 'false';
+}
+
+/**
+ * Gets the report readonly status
+ */
+export function isReportReadonly(): boolean {
+  return process.env.REPORT_READONLY === 'true';
 }

--- a/src/lib/garak-parser.ts
+++ b/src/lib/garak-parser.ts
@@ -105,7 +105,8 @@ export function parseGarakReport(jsonlContent: string): GarakReportData {
         runId = (entry.run as string) || '';
         startTime = (entry.start_time as string) || '';
         garakVersion = (entry.garak_version as string) || '';
-      } else if (entry.entry_type === 'attempt') {
+      } else if (entry.entry_type === 'attempt' && entry.status === 2) {
+        // Only include status 2 (evaluated) attempts
         attempts.push(entry as unknown as GarakAttempt);
       } else if (entry.entry_type === 'digest') {
         evalData = entry;
@@ -115,7 +116,7 @@ export function parseGarakReport(jsonlContent: string): GarakReportData {
     }
   }
 
-  // Group attempts by probe category
+  // Group attempts by probe category (no deduplication needed since we only take status 2)
   const categoryMap = new Map<string, GarakAttempt[]>();
   
   for (const attempt of attempts) {


### PR DESCRIPTION
I found out that the report was showing duplicates - attempts with both status 1 and status 2.  

From the [docs](https://reference.garak.ai/en/latest/reporting.html#report-jsonl):
> Attempt-type entries have uuid and status fields. Status can be 0 (not sent to target), 1 (with target response but not evaluated), or 2 (with response and evaluation). Eval-type entries are added after each probe/detector pair completes, and list the results used to compute the score.

We were showing all statuses, when in reality we only want to display ones that were evaluated.  This was inflating the overall metrics, as well as skewing % vulnerable.

For the toggling vulnerable vs safe - we assume it's a 1 or a 0.  I also added a config to disable the ability to toggle it, `REPORT_READONLY`.  This defaults to false.  When set to true, you are shown a warning banner that it is in readonly mode, the toggle is not visible and the endpoint will return a 400 if used.

Closes #4 