### PR TITLE
REPORT_READONLY now prevents report upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ The following environment variables can be configured:
   - Absolute paths (starting with `/`) are used as-is
 
 #### `REPORT_READONLY` (Optional)
-- **Description**: Controls whether users can edit vulnerability scores in reports
+- **Description**: Controls whether the repository is in read-only mode
 - **Default**: `false`
 - **Values**: 
-  - `true`: Reports are read-only, vulnerability scores cannot be modified
-  - `false`: Users can toggle vulnerability scores to mark false positives/negatives
+  - `true`: Read-only mode - disables all state-changing operations (report uploads, vulnerability score editing, upload UI hidden). To add reports in this mode, manually copy `.jsonl` files to the `REPORT_DIR` directory on the filesystem.
+  - `false`: Full access mode - users can upload reports and edit vulnerability scores through the web interface
 - **Use cases**: 
   - Set to `true` for production environments where report integrity must be preserved
   - Set to `false` for analysis environments where analysts need to mark false positives

--- a/example.env
+++ b/example.env
@@ -130,10 +130,14 @@ OIDC_MAX_AGE=3600
 # OIDC_PROVIDER_NAME=AWS Cognito
 # OIDC_SCOPES=openid,profile,email
 
-# Report Editing Configuration
-# Controls whether users can edit vulnerability scores in reports
-# When set to true, reports are read-only and vulnerability scores cannot be modified
-# When set to false (default), users can toggle vulnerability scores
+# Report Read-Only Configuration
+# Controls whether the repository is in read-only mode
+# When set to true, all state-changing operations are disabled:
+#   - Report uploads are blocked
+#   - Vulnerability score editing is disabled
+#   - Upload UI elements are hidden
+#   - To add reports in readonly mode, manually copy .jsonl files to REPORT_DIR
+# When set to false (default), users can upload reports and edit vulnerability scores
 REPORT_READONLY=false
 
 # Shared Secret Authentication for Machine-to-Machine Communication

--- a/src/app/api/upload-report/route.ts
+++ b/src/app/api/upload-report/route.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { validateFilename, buildSafeFilePath, buildSafeFolderPath, sanitizeError } from '@/lib/security';
 import { GarakReportEntry } from '@/lib/garak-parser';
 import { MAX_FILE_SIZE, ALLOWED_FILE_EXTENSIONS } from '@/lib/security-config';
+import { isReportReadonly } from '@/lib/config';
 
 // Get the report directory from environment variable
 function getReportDir(): string {
@@ -118,6 +119,14 @@ async function getUniqueFilename(reportDir: string, originalFilename: string): P
 
 export async function POST(request: NextRequest) {
   try {
+    // Check if reports are in readonly mode
+    if (isReportReadonly()) {
+      return NextResponse.json(
+        { error: 'Report uploads are disabled. Reports are in readonly mode.' },
+        { status: 403 }
+      );
+    }
+
     // Parse the multipart form data
     const formData = await request.formData();
     const file = formData.get('file') as File;

--- a/src/components/ReportSelector.tsx
+++ b/src/components/ReportSelector.tsx
@@ -36,6 +36,7 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
   const [itemsPerPage] = useState(10);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  const [isReadonly, setIsReadonly] = useState(false);
   const router = useRouter();
   const { isAuthenticated, isOIDCEnabled } = useAuth();
 
@@ -62,6 +63,22 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
   const handleUploadError = useCallback((error: string) => {
     console.error('Upload error:', error);
     // Error is already displayed in the FileUpload component
+  }, []);
+
+  // Fetch config on mount to check if reports are readonly
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await apiJson<{ reportReadonly: boolean }>('/api/config');
+        setIsReadonly(response.reportReadonly);
+      } catch (error) {
+        console.error('Failed to fetch config:', error);
+        // Default to readonly on error for safety
+        setIsReadonly(true);
+      }
+    };
+    
+    fetchConfig();
   }, []);
 
   useEffect(() => {
@@ -235,7 +252,10 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
               <div>
                 <h1 className="text-3xl font-bold text-gray-900">Garak Repository</h1>
                 <p className="mt-2 text-gray-600">
-                  Upload your first Garak report to get started
+                  {isReadonly 
+                    ? 'Repository is in read-only mode'
+                    : 'Upload your first Garak report to get started'
+                  }
                 </p>
               </div>
               <div className="flex items-center space-x-4">
@@ -243,12 +263,14 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
                   <div className="text-2xl font-bold text-gray-900">0</div>
                   <div className="text-sm text-gray-600">Available Reports</div>
                 </div>
-                <button
-                  onClick={() => setShowUploadModal(true)}
-                  className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-                >
-                  Upload Report
-                </button>
+                {!isReadonly && (
+                  <button
+                    onClick={() => setShowUploadModal(true)}
+                    className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+                  >
+                    Upload Report
+                  </button>
+                )}
                 {isAuthenticated && isOIDCEnabled && (
                   <LogoutButton />
                 )}
@@ -266,13 +288,20 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
               </svg>
             </div>
             <h3 className="text-lg font-medium text-gray-900 mb-2">No Reports Found</h3>
-            <p className="text-gray-600 mb-6">No Garak report files found in the data directory.</p>
-            <button
-              onClick={() => setShowUploadModal(true)}
-              className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors text-lg"
-            >
-              Upload Your First Report
-            </button>
+            <p className="text-gray-600 mb-6">
+              {isReadonly 
+                ? 'No Garak report files found in the data directory. Repository is in read-only mode.'
+                : 'No Garak report files found in the data directory.'
+              }
+            </p>
+            {!isReadonly && (
+              <button
+                onClick={() => setShowUploadModal(true)}
+                className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors text-lg"
+              >
+                Upload Your First Report
+              </button>
+            )}
           </div>
         </div>
 
@@ -296,7 +325,10 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
             <div>
               <h1 className="text-3xl font-bold text-gray-900">Garak Repository</h1>
               <p className="mt-2 text-gray-600">
-                Select a report to view detailed analysis
+                {isReadonly 
+                  ? 'Select a report to view detailed analysis (read-only mode)'
+                  : 'Select a report to view detailed analysis'
+                }
               </p>
             </div>
             <div className="flex items-center space-x-4">
@@ -306,12 +338,14 @@ export function ReportSelector({ onReportSelect }: ReportSelectorProps) {
                   {searchTerm ? 'Filtered Reports' : 'Available Reports'}
                 </div>
               </div>
-              <button
-                onClick={() => setShowUploadModal(true)}
-                className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-              >
-                Upload Report
-              </button>
+              {!isReadonly && (
+                <button
+                  onClick={() => setShowUploadModal(true)}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+                >
+                  Upload Report
+                </button>
+              )}
               {isAuthenticated && isOIDCEnabled && (
                 <LogoutButton />
               )}


### PR DESCRIPTION
Closes #24 

The `REPORT_READONLY` env var will now disable the ability to upload reports.  To add reports in the `readonly` mode, you must manually add them to the underlying filesystem in the configured `REPORT_DIR`.