### PR TITLE
Adding caching for garak-report-metadata endpoint

### DIFF
--- a/src/app/api/garak-report-toggle/route.ts
+++ b/src/app/api/garak-report-toggle/route.ts
@@ -8,6 +8,7 @@ import {
   sanitizeError 
 } from '@/lib/security';
 import { isReportReadonly } from '@/lib/config';
+import { getCache, getReportMetadataCacheKey } from '@/lib/cache';
 
 /**
  * @swagger
@@ -234,6 +235,11 @@ export async function POST(request: Request) {
     // Write the updated content back to the file
     const updatedContent = updatedLines.join('\n');
     writeFileSync(pathValidation.filePath!, updatedContent, 'utf-8');
+    
+    // Invalidate cache for this report since metadata has changed
+    const cache = getCache();
+    const cacheKey = getReportMetadataCacheKey(filename);
+    cache.delete(cacheKey);
     
     return NextResponse.json({ 
       success: true, 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,109 @@
+import { InMemoryLRUCache } from './cache/in-memory-lru-cache';
+// Future implementations can be imported here:
+// import { RedisCache } from './cache/redis-cache';
+
+/**
+ * Cache Interface
+ * 
+ * Abstraction for caching implementations to allow easy swapping
+ * between in-memory, Redis, or other cache backends.
+ */
+export interface Cache {
+  /**
+   * Get a value from the cache
+   * @param key Cache key
+   * @returns Cached value or null if not found
+   */
+  get<T>(key: string): T | null;
+
+  /**
+   * Set a value in the cache
+   * @param key Cache key
+   * @param value Value to cache
+   * @param ttlMs Optional time-to-live in milliseconds
+   */
+  set<T>(key: string, value: T, ttlMs?: number): void;
+
+  /**
+   * Delete a value from the cache
+   * @param key Cache key
+   */
+  delete(key: string): void;
+
+  /**
+   * Clear all entries from the cache
+   */
+  clear(): void;
+
+  /**
+   * Check if a key exists in the cache
+   * @param key Cache key
+   * @returns true if key exists, false otherwise
+   */
+  has(key: string): boolean;
+
+  /**
+   * Get cache statistics (optional, for monitoring)
+   */
+  getStats?(): CacheStats;
+}
+
+export interface CacheStats {
+  size: number;
+  maxSize: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+}
+
+/**
+ * Get the cache instance
+ * This factory function allows easy swapping of cache implementations
+ * based on configuration (e.g., CACHE_TYPE environment variable)
+ */
+let cacheInstance: Cache | null = null;
+
+export function getCache(): Cache {
+  if (!cacheInstance) {
+    // Determine which cache implementation to use based on config
+    // For now, we only have in-memory LRU cache
+    // In the future, this could check CACHE_TYPE env var:
+    // const cacheType = process.env.CACHE_TYPE || 'in-memory';
+    // switch (cacheType) {
+    //   case 'redis':
+    //     cacheInstance = new RedisCache(...);
+    //     break;
+    //   default:
+    //     cacheInstance = new InMemoryLRUCache(maxMemoryBytes);
+    // }
+    const maxMemoryBytes = getCacheMaxMemoryBytes();
+    cacheInstance = new InMemoryLRUCache(maxMemoryBytes);
+  }
+  return cacheInstance;
+}
+
+/**
+ * Get the maximum memory for the cache in bytes
+ */
+function getCacheMaxMemoryBytes(): number {
+  const envValue = process.env.CACHE_MAX_MEMORY_MB;
+  if (!envValue) {
+    return 100 * 1024 * 1024; // Default 100MB
+  }
+
+  const mb = parseInt(envValue, 10);
+  if (isNaN(mb) || mb <= 0) {
+    console.warn(`Invalid CACHE_MAX_MEMORY_MB value: ${envValue}, using default 100MB`);
+    return 100 * 1024 * 1024;
+  }
+
+  return mb * 1024 * 1024;
+}
+
+/**
+ * Generate a cache key for report metadata
+ */
+export function getReportMetadataCacheKey(filename: string): string {
+  return `report-metadata:${filename}`;
+}
+

--- a/src/lib/cache/in-memory-lru-cache.ts
+++ b/src/lib/cache/in-memory-lru-cache.ts
@@ -1,0 +1,209 @@
+import { Cache, CacheStats } from '../cache';
+
+/**
+ * Cache entry with optional expiration
+ */
+interface CacheEntry<T> {
+  value: T;
+  expiresAt?: number;
+  size: number; // Estimated size in bytes
+}
+
+/**
+ * In-memory LRU cache implementation
+ * 
+ * Features:
+ * - LRU eviction when memory limit is reached
+ * - Optional TTL support
+ * - Memory-aware eviction based on estimated entry sizes
+ * - Cache statistics
+ */
+export class InMemoryLRUCache implements Cache {
+  private cache: Map<string, CacheEntry<unknown>>;
+  private maxMemoryBytes: number;
+  private currentMemoryBytes: number;
+  private hits: number;
+  private misses: number;
+  private evictions: number;
+  private accessOrder: string[]; // Track access order for LRU
+
+  constructor(maxMemoryBytes: number = 100 * 1024 * 1024) { // Default 100MB
+    this.cache = new Map();
+    this.maxMemoryBytes = maxMemoryBytes;
+    this.currentMemoryBytes = 0;
+    this.hits = 0;
+    this.misses = 0;
+    this.evictions = 0;
+    this.accessOrder = [];
+  }
+
+  get<T>(key: string): T | null {
+    const entry = this.cache.get(key);
+    
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    // Check if entry has expired
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.delete(key);
+      this.misses++;
+      return null;
+    }
+
+    // Update access order for LRU
+    this.updateAccessOrder(key);
+    this.hits++;
+    
+    return entry.value as T;
+  }
+
+  set<T>(key: string, value: T, ttlMs?: number): void {
+    const estimatedSize = this.estimateSize(value);
+    
+    // Remove existing entry if present
+    if (this.cache.has(key)) {
+      const oldEntry = this.cache.get(key)!;
+      this.currentMemoryBytes -= oldEntry.size;
+      this.removeFromAccessOrder(key);
+    }
+
+    // Evict entries if needed to make room
+    while (this.currentMemoryBytes + estimatedSize > this.maxMemoryBytes && this.cache.size > 0) {
+      this.evictLRU();
+    }
+
+    const entry: CacheEntry<T> = {
+      value,
+      expiresAt: ttlMs ? Date.now() + ttlMs : undefined,
+      size: estimatedSize,
+    };
+
+    this.cache.set(key, entry);
+    this.currentMemoryBytes += estimatedSize;
+    this.updateAccessOrder(key);
+  }
+
+  delete(key: string): void {
+    const entry = this.cache.get(key);
+    if (entry) {
+      this.currentMemoryBytes -= entry.size;
+      this.cache.delete(key);
+      this.removeFromAccessOrder(key);
+    }
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.currentMemoryBytes = 0;
+    this.accessOrder = [];
+    this.hits = 0;
+    this.misses = 0;
+    this.evictions = 0;
+  }
+
+  has(key: string): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return false;
+    }
+    
+    // Check if expired
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.delete(key);
+      return false;
+    }
+    
+    return true;
+  }
+
+  getStats(): CacheStats {
+    return {
+      size: this.cache.size,
+      maxSize: Math.floor(this.maxMemoryBytes / 1024), // Convert to KB for display
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    };
+  }
+
+  /**
+   * Evict the least recently used entry
+   */
+  private evictLRU(): void {
+    if (this.accessOrder.length === 0) {
+      return;
+    }
+
+    const lruKey = this.accessOrder[0];
+    this.delete(lruKey);
+    this.evictions++;
+  }
+
+  /**
+   * Update access order - move key to end (most recently used)
+   */
+  private updateAccessOrder(key: string): void {
+    this.removeFromAccessOrder(key);
+    this.accessOrder.push(key);
+  }
+
+  /**
+   * Remove key from access order
+   */
+  private removeFromAccessOrder(key: string): void {
+    const index = this.accessOrder.indexOf(key);
+    if (index > -1) {
+      this.accessOrder.splice(index, 1);
+    }
+  }
+
+  /**
+   * Estimate the size of a value in bytes
+   * This is a rough estimate for memory management
+   */
+  private estimateSize(value: unknown): number {
+    if (value === null || value === undefined) {
+      return 0;
+    }
+
+    if (typeof value === 'string') {
+      // UTF-16 encoding: 2 bytes per character
+      return value.length * 2;
+    }
+
+    if (typeof value === 'number') {
+      return 8; // 64-bit number
+    }
+
+    if (typeof value === 'boolean') {
+      return 4;
+    }
+
+    if (Array.isArray(value)) {
+      let size = 0;
+      for (const item of value) {
+        size += this.estimateSize(item);
+      }
+      return size + (value.length * 8); // Array overhead
+    }
+
+    if (typeof value === 'object') {
+      let size = 0;
+      for (const [k, v] of Object.entries(value)) {
+        size += k.length * 2; // Key size (UTF-16)
+        size += this.estimateSize(v);
+      }
+      return size + 100; // Object overhead
+    }
+
+    // Fallback: estimate based on JSON stringification
+    try {
+      return JSON.stringify(value).length * 2; // UTF-16
+    } catch {
+      return 1024; // Conservative estimate for unknown types
+    }
+  }
+}
+


### PR DESCRIPTION
Closes #23 

Only implemented for the `garak-report-metadata` endpoint, which will _significantly_ improve performance of loading a report.  Loading attempts is still slow and likely won't be resolved via caching...